### PR TITLE
Container support in FIFA Tracker

### DIFF
--- a/Dockerfile-webapp
+++ b/Dockerfile-webapp
@@ -1,0 +1,16 @@
+FROM alpine:3.12
+# install Python
+RUN apk add python3-dev py3-pip musl-dev gcc postgresql-dev
+RUN pip3 install --ignore-installed virtualenv
+
+# setup virtualenv
+RUN mkdir -p /app/
+WORKDIR /app/
+RUN virtualenv FT_ENV
+RUN source FT_ENV/bin/activate
+
+# install python reqs
+COPY requirements.txt /requirements.txt
+RUN pip3 install --ignore-installed -r /requirements.txt
+
+RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+# Configures a db container and a web container to run FIFA Tracker
+# 
+# After it's all running do this:
+#    docker exec fifatracker-docker_db_1 sh /load_csvs.sh
+ 
+version: "3"
+services:
+    db:
+        image: postgres:10-alpine
+        ports: 
+            -  "5432:5432"   
+        volumes:
+            - ./Database Data:/Database Data
+            - ./docker/install_extension.sql:/docker-entrypoint-initdb.d/install_extension.sql
+            - ./docker/load_csvs.sh:/load_csvs.sh
+            - db-data:/var/lib/postgresql/data
+        # make sure to update the database password here
+        environment: 
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=
+            - POSTGRES_DB=FIFA_TRACKER
+        restart: unless-stopped
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+    web:
+        build:
+            context: .
+            dockerfile: Dockerfile-webapp
+        image: webapp
+        ports:
+            - "8000:8000"
+        volumes:
+            - ./FIFATracker:/app
+            - ./docker/.env:/app/.env
+            - ./docker/manage_migrations.sh:/app/manage_migrations.sh
+            - ./docker/manage_datausersplayers.sh:/app/manage_datausersplayers.sh
+        depends_on: 
+            - db
+        working_dir: /app
+        command: sh -cx "
+            python manage.py runserver 0.0.0.0:8000"
+        restart: unless-stopped
+        healthcheck:
+            test: curl --fail -s http://localhost:8000/ || exit 1
+            interval: 1m30s
+            timeout: 10s
+            retries: 3
+volumes:
+    db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,4 @@
 # Configures a db container and a web container to run FIFA Tracker
-# 
-# After it's all running do this:
-#    docker exec fifatracker-docker_db_1 sh /load_csvs.sh
  
 version: "3"
 services:

--- a/docker/README.md
+++ b/docker/README.md
@@ -107,8 +107,8 @@ The database stores all of it's data on the `db-data` volume that persists acros
 It needs to be at the root of the repo so it can reference files at the root. 
 
 ## Dockerfile-webapp
-This file sets up the environment for the web container. They need to be at the root of the repo so they can reference files at the root. 
-No Dockerfile is needed for the database since there are no environment changes needed to the image (besides adding a few files that docker-compose volumes handles.)
+This file sets up the environment for the web container. It needs to be at the root of the repo so it can reference files at the root. 
+No Dockerfile is needed for the database since there are no environment changes needed to the image (besides adding a few files that docker-compose volumes handles)
 
 ## install_extension.sql
 When the postgres container starts for the first time it will look in `docker-entrypoint-initdb.d/` for any sql files to execute. The `install_extension.sql` will then get executed to add the `unaccent` extension. 
@@ -116,9 +116,9 @@ When the postgres container starts for the first time it will look in `docker-en
 ## post-run bash scripts
 A few bash scripts are need to run after the first start of containers to initialize data. These will need to be manually run. The order is as follows. 
 
-1. `manage_migrations.sh`: This will initialize the django webapp and add some tables the database. Run this inside the web container. 
-2. `manage_datausersplayers.sh`: This initializes a few more fields in django and the database. Run this inside the web container. 
-3. `load_csvs.sh`: This loads in default data into the database. 
+1. `manage_migrations.sh`: This will initialize the django webapp and add some tables the database. Run this inside the web container via `docker exec`. 
+2. `manage_datausersplayers.sh`: This initializes a few more fields in django and the database. Run this inside the web container via `docker exec`. 
+3. `load_csvs.sh`: This loads in default data into the database via `docker exec`.
 
 ## .env
 Stores configuration information about the webapp. Ideally we should be using `secret_settings.py` but that was not being referenced, so we fall back to using `.env`. 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,124 @@
+# Container Support
+Here's everything needed to run FIFA Tracker in containers.  
+  
+It uses `docker` for the conatiners and `docker-compose` to coorindate the database and web containers. 
+
+- [Container Support](#container-support)
+- [Configuration](#configuration)
+- [Getting Started](#getting-started)
+  - [Install Docker](#install-docker)
+  - [Prepare Containers](#prepare-containers)
+  - [Load Data](#load-data)
+  - [Cleanup and Finish](#cleanup-and-finish)
+- [Technical Details](#technical-details)
+  - [docker-compose.yml](#docker-composeyml)
+  - [Dockerfile-webapp](#dockerfile-webapp)
+  - [install_extension.sql](#install_extensionsql)
+  - [post-run bash scripts](#post-run-bash-scripts)
+  - [.env](#env)
+
+# Configuration
+* Ensure you set the database username and passwords and SECRET_KEY located in `.env` and `docker-compose.yml`. 
+* Also configure your ALLOWED_HOSTS in the `.env` file to contain the external facing IP of your server. 
+
+# Getting Started
+
+## Install Docker
+* Prepare a container host to run the docker containers. For this testing a `Debian 9` host was used. 
+* Install preqs (via: https://docs.docker.com/engine/install/debian/)
+    ```
+    sudo apt update
+    sudo apt install apt-transport-https ca-certificates curl gnupg2 software-properties-common
+    ```
+* Install Docker's GPG Key
+  ```
+  curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+  ```
+* Add Docker repo
+  ```
+  sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+  ```
+* Install Docker Engine
+  ```
+  sudo apt update
+  sudo apt install docker-ce docker-ce-cli containerd.io
+  ```
+* Install docker-compose (https://docs.docker.com/compose/install/)
+  ```
+  sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+
+  sudo chmod +x /usr/local/bin/docker-compose
+  ```
+  
+## Prepare Containers
+* Grab this repo into your working directory via `git clone`
+* Configure the database usernames, passwords and the web server ALLOWED_HOSTS and SECRET_KEY in the `.env` and `docker-compose.yml` files. See [Configuration](#configuration)
+* Navigate into root directory of repo. You should see `docker-compose.yml` in your working directory
+
+* Build docker containers via docker-compose
+  ```
+  docker-compose build
+  ```
+* Start the docker conatiners via docker-compose
+  ```
+  docker-compose up
+  ```
+## Load Data
+In another terminal run the following to initialise the data. Only need to do this once.
+> Notice the name of the docker container called. e.g. `fifa-tracker_web_1` or `fifa-tracker_db_1`. Take a look at `docker ps` for the name of your containers
+* Load database schemas and kickoff migrations
+  ```
+  docker exec fifa-tracker_web_1 sh manage_migrations.sh
+  ```
+* Fix datausersplayers
+  ```
+  docker exec fifa-tracker_web_1 sh manage_datausersplayers.sh
+  ```
+* Load database data
+  ```
+  docker exec fifa-tracker_db_1 sh /load_csvs.sh
+  ```
+  > There will be the following errors. Not sure how to handle them. If you're not using FIFA 17 or 18 it probably doesn't matter.   
+  > `ERROR:  relation "dataplayernames18" does not exist`  
+  > `ERROR:  relation "datanations18" does not exist`  
+  > `ERROR:  duplicate key value violates unique constraint "dataplayernames17_pkey"`
+
+## Cleanup and Finish
+* Restart docker container to ensure changes took effect
+  ```
+  docker-compose stop
+  docker-compose up
+  ```
+* All done! Access web url via `http://<your-ip>:8000`
+
+# Technical Details
+Here's a description of all the files and their usage. If you just want to run the app, feel free to ignore this section.
+
+## docker-compose.yml
+This file coordinates the database and web container. It's what's used to fire up the two docker containers. They include what to run when the container starts, how to ensure they're running healthy, and any environment, network, or disk volumes required.   
+
+The two containers talk to eachother on back channels that docker compose configures.   
+
+The database stores all of it's data on the `db-data` volume that persists across restarts. 
+
+It needs to be at the root of the repo so it can reference files at the root. 
+
+## Dockerfile-webapp
+This file sets up the environment for the web container. They need to be at the root of the repo so they can reference files at the root. 
+No Dockerfile is needed for the database since there are no environment changes needed to the image (besides adding a few files that docker-compose volumes handles.)
+
+## install_extension.sql
+When the postgres container starts for the first time it will look in `docker-entrypoint-initdb.d/` for any sql files to execute. The `install_extension.sql` will then get executed to add the `unaccent` extension. 
+
+## post-run bash scripts
+A few bash scripts are need to run after the first start of containers to initialize data. These will need to be manually run. The order is as follows. 
+
+1. `manage_migrations.sh`: This will initialize the django webapp and add some tables the database. Run this inside the web container. 
+2. `manage_datausersplayers.sh`: This initializes a few more fields in django and the database. Run this inside the web container. 
+3. `load_csvs.sh`: This loads in default data into the database. 
+
+## .env
+Stores configuration information about the webapp. Ideally we should be using `secret_settings.py` but that was not being referenced, so we fall back to using `.env`. 

--- a/docker/install_extension.sql
+++ b/docker/install_extension.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION unaccent

--- a/docker/load_csvs.sh
+++ b/docker/load_csvs.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Load the data into the database
+psql -d FIFA_TRACKER --username=postgres -c "COPY dataplayernames20 (name,nameid,commentaryid) FROM '/Database Data/playernames20.csv' delimiter ',' csv header ENCODING 'UTF8';"
+psql -d FIFA_TRACKER --username=postgres -c "COPY datanations20 (isocountrycode,nationname,confederation,top_tier,nationstartingfirstletter,groupid,nationid) FROM '/Database Data/nations20.csv' delimiter ',' csv header ENCODING 'UTF8';"
+
+psql -d FIFA_TRACKER --username=postgres -c "COPY dataplayernames19 (name,nameid,commentaryid) FROM '/Database Data/playernames19.csv' delimiter ',' csv header ENCODING 'UTF8';"
+psql -d FIFA_TRACKER --username=postgres -c "COPY datanations19 (isocountrycode,nationname,confederation,top_tier,nationstartingfirstletter,groupid,nationid) FROM '/Database Data/nations19.csv' delimiter ',' csv header ENCODING 'UTF8';"
+
+psql -d FIFA_TRACKER --username=postgres -c "COPY dataplayernames18 (name,nameid,commentaryid) FROM '/Database Data/playernames18.csv' delimiter ',' csv header ENCODING 'UTF8';"
+psql -d FIFA_TRACKER --username=postgres -c "COPY datanations18 (isocountrycode,nationname,confederation,top_tier,nationstartingfirstletter,groupid,nationid) FROM '/Database Data/nations18.csv' delimiter ',' csv header ENCODING 'UTF8';"
+
+psql -d FIFA_TRACKER --username=postgres -c "COPY dataplayernames17 (name,nameid,commentaryid) FROM '/Database Data/playernames17.csv' delimiter ',' csv header ENCODING 'UTF8';"
+psql -d FIFA_TRACKER --username=postgres -c "COPY datanations17 (isocountrycode,nationname,confederation,top_tier,nationstartingfirstletter,groupid,nationid) FROM '/Database Data/nations17.csv' delimiter ',' csv header ENCODING 'UTF8';"

--- a/docker/manage_datausersplayers.sh
+++ b/docker/manage_datausersplayers.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# This script handles this issue: https://github.com/xAranaktu/FIFA-Tracker/issues/9
+
+# comment out "For Release"
+sed -i '/firstname = models.ForeignKey/,/Uncomment for migration to fix problem with foreignkeys/s/.*/#&/' players/models.py
+# uncomment "migration fix problem with foreignkeys"
+sed -i '/firstnameid = models.IntegerField/,/commonnameid = models.IntegerField/s/# //' players/models.py
+sleep 1
+echo "running migrations fix problem with foreignkeys"
+
+python manage.py makemigrations
+python manage.py migrate
+sleep 1
+
+# uncomment "For Release"
+sed -i '/firstname = models.ForeignKey/,/Uncomment for migration to fix problem with foreignkeys/s/#//' players/models.py
+# comment out "migration fix problem with foreignkeys"
+sed -i '/firstnameid = models.IntegerField/,/commonnameid = models.IntegerField/s/.*/#&/' players/models.py
+sleep 1
+echo "running migrations for release"
+
+python manage.py makemigrationsn
+python manage.py migrate --fake

--- a/docker/manage_migrations.sh
+++ b/docker/manage_migrations.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+python manage.py makemigrations
+
+# Setup null primary keys 
+python manage.py migrate players 0001
+python manage.py migrate --fake players 0002
+python manage.py migrate


### PR DESCRIPTION
This PR adds the ability to run FIFA Tracker from docker containers. See docker/README.md for documentation on how it works. 